### PR TITLE
Amend cutout nonzero

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # matheo
 
-Matheo is a python package with mathematical algorithms for use in earth observation data and tools.
+Matheo is a python package with mathematical algorithms for use in Earth observation data and tools.
 
 
 ## Installation

--- a/matheo/band_integration/band_integration.py
+++ b/matheo/band_integration/band_integration.py
@@ -33,11 +33,18 @@ def cutout_nonzero(y, x, buffer=0.2):
     :type buffer: float
     :param buffer: fraction of non-zero section of y to include as buffer on either side (default: 0.2)
     """
-
     # Find extent of non-zero region
-    idx = np.nonzero(y)
-    imin = min(idx[0])
-    imax = max(idx[0]) + 1
+    max_val = max(y)
+    idx_range = np.zeros(len(y)) * np.nan
+
+    for idx, val in enumerate(y):
+        if val > 0.1 * max_val:
+            idx_range[idx] = idx
+
+    idx_range = idx_range[np.isfinite(idx_range)]
+
+    imin = int(min(idx_range))
+    imax = int(max(idx_range)) + 1
 
     # Determine buffer
     width = imax - imin

--- a/matheo/band_integration/band_integration.py
+++ b/matheo/band_integration/band_integration.py
@@ -23,8 +23,8 @@ __created__ = "30/7/2021"
 def cutout_nonzero(
     y: np.ndarray,
     x: np.ndarray,
-    buffer: Union[float, int] = 0.2,
-    relative_threshold: Union[float, int] = 0.0,
+    buffer: Optional[Union[float, int]] = 0.2,
+    relative_threshold: Optional[Union[float, int]] = 0.0,
 ) -> Tuple[np.ndarray, np.ndarray, List[int]]:
     """
     Returns continuous non-zero part of function y(x)

--- a/matheo/band_integration/band_integration.py
+++ b/matheo/band_integration/band_integration.py
@@ -20,7 +20,12 @@ __author__ = "Sam Hunt"
 __created__ = "30/7/2021"
 
 
-def cutout_nonzero(y: np.ndarray, x: np.ndarray, buffer: Union[float, int]=0.2, relative_threshold: Union[float, int]=0.) -> Tuple[np.ndarray, np.ndarray, List[int]]:
+def cutout_nonzero(
+    y: np.ndarray,
+    x: np.ndarray,
+    buffer: Union[float, int] = 0.2,
+    relative_threshold: Union[float, int] = 0.0,
+) -> Tuple[np.ndarray, np.ndarray, List[int]]:
     """
     Returns continuous non-zero part of function y(x)
 

--- a/matheo/band_integration/band_integration.py
+++ b/matheo/band_integration/band_integration.py
@@ -20,25 +20,22 @@ __author__ = "Sam Hunt"
 __created__ = "30/7/2021"
 
 
-def cutout_nonzero(y, x, buffer=0.2):
+def cutout_nonzero(y: np.ndarray, x: np.ndarray, buffer: Union[float, int]=0.2, relative_threshold: Union[float, int]=0.) -> Tuple[np.ndarray, np.ndarray, List[int]]:
     """
     Returns continuous non-zero part of function y(x)
 
-    :type y: numpy.ndarray
     :param y: function data values
-
-    :type x: numpy.ndarray
     :param x: function coordinate data values
-
-    :type buffer: float
     :param buffer: fraction of non-zero section of y to include as buffer on either side (default: 0.2)
+    :param relative_threshold: (default: 0.) relative threshold to define non-zero region, as fraction of maximum value in y.
+    :return: y, x, [imin, imax] - where imin and imax are indices of the start and end of the non-zero region
     """
     # Find extent of non-zero region
     max_val = max(y)
     idx_range = np.zeros(len(y)) * np.nan
 
     for idx, val in enumerate(y):
-        if val > 0.1 * max_val:
+        if val > relative_threshold * max_val:
             idx_range[idx] = idx
 
     idx_range = idx_range[np.isfinite(idx_range)]

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,11 @@ def read(filename):
 setup(
     version=__version__,
     name="matheo",
-    url="https://gitlab.npl.co.uk/eco/tools/matheo",
+    url="https://github.com/meteor-toolkit/matheo",
     license="None",
     author="Sam Hunt, Pieter De Vis",
     author_email="sam.hunt@npl.co.uk",
-    description="Matheo is a python package with mathematical algorithms for use in earth observation data and tools",
+    description="Matheo is a python package with mathematical algorithms for use in Earth observation data and tools",
     long_description=read("README.md"),
     packages=find_packages(exclude=("tests",)),
     install_requires=["pyspectral", "comet_maths>=1.0.5", "punpy>=1.0.4"],


### PR DESCRIPTION
When cutting out non-zero region of spectral response function, cut to region <0.1 * max(SRF) rather than exactly zero. Some SRFs don't go to zero, but go to very near zero which causes issues in the current implementation.

Implemented by Samantha Malone originally on gitlab & I have made the change on github version.